### PR TITLE
Desenvolvimento de um container de página para estabelecer padrões de largura delas e de seus elementos

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import Router from "./Router.svelte";
+  import PageContainer from "./components/PageContainer.svelte";
 </script>
 
-<Router />
+<PageContainer>
+  <Router />
+</PageContainer>

--- a/src/Router.svelte
+++ b/src/Router.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Router, Link, Route } from "svelte-navigator";
+  import { Router, Route } from "svelte-navigator";
 
 	import Home from "./pages/Home.svelte";
 	import BorrowBooks from "./pages/BorrowBooks.svelte";

--- a/src/components/PageContainer.svelte
+++ b/src/components/PageContainer.svelte
@@ -1,0 +1,27 @@
+<main class="page-container">
+  <slot></slot>
+</main>
+
+<style>
+  :global(.page-container) {
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+  }
+
+  :global(.page-container > *) {
+    width: 45rem;
+    padding-inline: 0.625rem;
+  }
+
+  @media (max-width: 720px) {
+    :global(.page-container) {
+      align-items: initial;
+    }
+
+    :global(.page-container > *) {
+      width: auto;
+      max-width: 45rem;
+    }
+  }
+</style>


### PR DESCRIPTION
O objetivo desta tarefa era desenvolver um componente que fosse um container de página (PageContainer) que torna a largura das páginas responsiva, valendo desde monitores widescreen à telas de celular. Isso não cobre a responsividade de itens internos destas páginas. Apenas aborda a largura que a página como um todo terá.

Caso um item de uma página precisar ter uma largura que fuja do padrão criado com esse componente, é possível fazer isso na própria estilização da página ou do componente dela, sem ter de modificar a estilização do componente PageContainer.